### PR TITLE
feat: Add `ui_view` tool for compressed iOS simulator screenshots

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,13 @@
+# Context
+
+This document is a collection of relevant references to use as context (for humans and LLMs) for working on this project.
+
+- [MCP Docs - Server Features - Tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
+  - [LLM optimized page](https://modelcontextprotocol.io/specification/2025-06-18/server/tools.md)
+- [iOS Simulator from the Command Line](https://suelan.github.io/2020/02/05/iOS-Simulator-from-the-Command-Line/)
+- [idb Commands](https://fbidb.io/docs/commands)
+  - [LLM optimized page](https://raw.githubusercontent.com/facebook/idb/refs/heads/main/website/docs/commands.mdx)
+- [sips man page for image compression](https://ss64.com/mac/sips.html)
+- [Claude Vision docs](https://docs.anthropic.com/en/docs/build-with-claude/vision)
+  - [LLM optimized page](https://docs.anthropic.com/en/docs/build-with-claude/vision.md)
+- [An Introduction to Command Injection Vulnerabilities in Node.js and JavaScript](https://www.nodejs-security.com/blog/introduction-command-injection-vulnerabilities-nodejs-javascript)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-simulator-mcp",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "MCP server for interacting with the iOS simulator",
   "bin": {
     "ios-simulator-mcp": "./build/index.js"


### PR DESCRIPTION
### Overview
This PR adds a new `ui_view` tool to the iOS Simulator MCP server that captures and returns compressed screenshots of the current simulator view.

### Changes
- **New Feature**: Added `ui_view` tool that:
  - Captures simulator screenshots as PNG using `xcrun simctl`
  - Compresses images to JPEG format using `sips` with 80% quality and max 1568px height
  - Returns base64-encoded compressed images to reduce data transfer
  - Includes proper error handling and troubleshooting messages

- **Infrastructure**: 
  - Added temporary file management with automatic cleanup on server shutdown
  - Imported `fs` module for file operations
  - Created `TMP_ROOT_DIR` for storing temporary screenshot files

- **Documentation**: Added `CONTEXT.md` with relevant references including:
  - MCP documentation links
  - iOS Simulator command line reference
  - idb commands documentation
  - Image compression (sips) documentation
  - Claude Vision API documentation
  - Security best practices for command injection prevention

- **Version**: Bumped to 1.4.0 to reflect the new feature

### Technical Details
- Screenshots are captured as PNG first for quality, then compressed to JPEG for efficient transfer
- Temporary files use unique timestamps to avoid conflicts
- All temporary files are cleaned up on server shutdown
- The tool respects the existing UDID parameter pattern for device targeting
- Image compression reduces file size while maintaining visual quality for AI analysis

### Usage
The new tool can be called with an optional `udid` parameter to target a specific simulator device. It returns the screenshot as a base64-encoded JPEG image along with a success message.

### Screen Recording

https://github.com/user-attachments/assets/217c0617-3f8a-4434-8983-bd6ee9153bb8


