### PR TITLE
Update TROUBLESHOOTING.md

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -78,6 +78,7 @@ The installation section in [IDB](https://fbidb.io/docs/installation/) is a litt
 ### Simulator UI Not Responding
 - Restart the simulator and try again.
 - Quit and relaunch Xcode if needed.
+- Prompt AI to check dimensions of the simulator screen and adjust coordinates to it. Screenshots have 3x resolution and this may result in incorrect position of screen presses.
 
 ## 4. Still Stuck?
 - Check the [README](./README.md) for setup and usage instructions.


### PR DESCRIPTION
Hi, 
While using iOS simulator MCP, I ran into an issue with screen presses not being registered. I made sure to have IDB installed and simulator restarted as suggested in TROUBLESHOOTING.md.

@lukemorawski suggested adding prompt for AI to check window dimensions of the simulator as screenshots have 3x resolution, which might cause it to press at the wrong coordinates. I tested this on my app and it fixed the issue! 

Hopefully this information can be helpful to others who run into similar issue.