### PR TITLE
chore: add `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ https://github.com/user-attachments/assets/453ebe7b-cc93-4ac2-b08d-0f8ac8339ad3
   - Show a view of the simulator screen to your AI agent
 - Filter specific tools using environment variables
 
-## Configuration
-
-### Environment Variables
-
-- `IOS_SIMULATOR_MCP_FILTERED_TOOLS`: A comma-separated list of tool names to filter out from being registered. For example: `screenshot,record_video,stop_recording`
-
 ## 💡 Use Case: QA Step via MCP Tool Calls
 
 This MCP server allows AI assistants integrated with a Model Context Protocol (MCP) client to perform Quality Assurance tasks by making tool calls. This is useful immediately after implementing features to help ensure UI consistency and correct behavior.
@@ -82,7 +76,7 @@ After a feature implementation, instruct your AI assistant within its MCP client
 - **Record Video:**
 
   ```
-  Start recording a video of the simulator screen (saves to ~/Downloads/simulator_recording_$DATE.mp4 by default)
+  Start recording a video of the simulator screen (saves to the default output directory, which is `~/Downloads` unless overridden by `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR`)
   ```
 
 - **Stop Recording:**
@@ -182,6 +176,32 @@ Claude Code CLI can manage MCP servers using the `claude mcp` commands or by edi
     **Important:** Replace `/full/path/to/your/` with the absolute path to where you cloned the `ios-simulator-mcp` repository.
 3.  Restart any running Claude Code sessions if necessary.
 
+## Configuration
+
+### Environment Variables
+
+| Variable                               | Description                                                                                                                                                                                          | Example                                  |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `IOS_SIMULATOR_MCP_FILTERED_TOOLS`     | A comma-separated list of tool names to filter out from being registered.                                                                                                                            | `screenshot,record_video,stop_recording` |
+| `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` | Specifies a default directory for output files like screenshots and video recordings. If not set, `~/Downloads` will be used. This can be handy if your agent has limited access to the file system. | `~/Code/awesome-project/tmp`             |
+
+#### Configuration Example
+
+```json
+{
+  "mcpServers": {
+    "ios-simulator": {
+      "command": "npx",
+      "args": ["-y", "ios-simulator-mcp"],
+      "env": {
+        "IOS_SIMULATOR_MCP_FILTERED_TOOLS": "screenshot,record_video,stop_recording",
+        "IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR": "~/Code/awesome-project/tmp"
+      }
+    }
+  }
+}
+```
+
 ## MCP Registry Server Listings
 
 <a href="https://glama.ai/mcp/servers/@joshuayoes/ios-simulator-mcp">
@@ -189,7 +209,6 @@ Claude Code CLI can manage MCP servers using the `claude mcp` commands or by edi
 </a>
 
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/joshuayoes-ios-simulator-mcp-badge.png)](https://mseep.ai/app/joshuayoes-ios-simulator-mcp)
-
 
 ## License
 


### PR DESCRIPTION
# Why

This was requested in https://github.com/joshuayoes/ios-simulator-mcp/issues/25 to allow for configuring the default output directory for AI editors like `opencode` which can be restricted to the current working directory.

# Test Plan

1. Checkout this PR
2. Follow [Local Development Guide](https://github.com/joshuayoes/ios-simulator-mcp?tab=readme-ov-file#option-2-local-development) to setup locally in Cursor
3. Follow new doc steps to add `"IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR": "~/Code/awesome-project/tmp"` to Cursor configuration.
4. Create a new test folder like `~/Code/awesome-project/tmp`.
5. Make sure an iOS Simulator is open on your computer.
6. Open an chat in cursor in agent mode and give the prompt "Take a screenshot of the current ios simulator screen".
7. Verify the output path is prefixed with `~/Code/awesome-project/tmp`
8. Do the same with a screen recording. 

<img width="1727" height="1001" alt="Screenshot 2025-08-16 at 9 13 51 AM" src="https://github.com/user-attachments/assets/243d3c62-ef9d-41f4-9fc5-d7b11ca21b95" />

<img width="1728" height="1024" alt="Screenshot 2025-08-16 at 9 15 40 AM" src="https://github.com/user-attachments/assets/7c119d19-0fe0-47ae-a886-befa7e062c2f" />

