### PR TITLE
add add duration to swipe gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ This project has been featured and mentioned in various publications and resourc
 ```typescript
 {
   /**
+   * Swipe duration in seconds (decimal numbers allowed)
+   */
+  duration?: string;
+  /**
    * Udid of target, can also be set with the IDB_UDID env var
    * Format: UUID (8-4-4-4-12 hexadecimal characters)
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,6 +318,11 @@ if (!isToolFiltered("ui_swipe")) {
     "ui_swipe",
     "Swipe on the screen in the iOS Simulator",
     {
+      duration: z
+        .string()
+        .regex(/^\d+(\.\d+)?$/)
+        .optional()
+        .describe("Swipe duration in seconds (e.g., 0.1)"),
       udid: z
         .string()
         .regex(UDID_REGEX)
@@ -333,7 +338,7 @@ if (!isToolFiltered("ui_swipe")) {
         .describe("The size of each step in the swipe (default is 1)")
         .default(1),
     },
-    async ({ udid, x_start, y_start, x_end, y_end, delta }) => {
+    async ({ duration, udid, x_start, y_start, x_end, y_end, delta }) => {
       try {
         const actualUdid = await getBootedDeviceId(udid);
 
@@ -342,6 +347,7 @@ if (!isToolFiltered("ui_swipe")) {
           "swipe",
           "--udid",
           actualUdid,
+          ...(duration ? ["--duration", duration] : []),
           ...(delta ? ["--delta", String(delta)] : []),
           "--json",
           // When passing user-provided values to a command, it's crucial to use `--`


### PR DESCRIPTION
## Why?

Swiping was not functional on my simulators (system specs can be provided if needed). Exposed the duration arg, now works when specifying a nonzero duration. 

## Manual Test Steps

1. Start iOS simulator: `xcrun simctl boot "iPhone 16"`
2. Configure MCP client to use local build
3. Test functionality: "Ask AI to swipe right until it finds the app search bar from the home screen"

## Checklist

- [x] I have read and followed the [Contributing Guide](CONTRIBUTING.md)
- [x] I have manually tested this with a real iOS simulator and MCP client
- [x] Updated README.md if adding new tools
