### PR TITLE
feat: add app management and simulator control tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ The server provides these tools (can be filtered via environment variables):
 - `screenshot` - Save screenshot to file
 - `record_video` - Start video recording
 - `stop_recording` - Stop video recording
+- `install_app` - Install an app bundle (.app or .ipa) on the simulator
+- `launch_app` - Launch an app by bundle identifier
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,48 @@ This project has been featured and mentioned in various publications and resourc
 
 **Parameters:** No Parameters
 
+### `install_app`
+
+**Description:** Installs an app bundle (.app or .ipa) on the iOS Simulator
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+  /** Path to the app bundle (.app directory or .ipa file) to install */
+  app_path: string;
+}
+```
+
+### `launch_app`
+
+**Description:** Launches an app on the iOS Simulator by bundle identifier
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+  /** Bundle identifier of the app to launch (e.g., com.apple.mobilesafari) */
+  bundle_id: string;
+  /** Wait for debugger to attach before launching */
+  wait_for_debugger?: boolean;
+  /** Attach to the app's stdout/stderr and print to console */
+  console?: boolean;
+  /** Terminate the app if it is already running before launching */
+  terminate_running?: boolean;
+}
+```
+
 ## 💡 Use Case: QA Step via MCP Tool Calls
 
 This MCP server allows AI assistants integrated with a Model Context Protocol (MCP) client to perform Quality Assurance tasks by making tool calls. This is useful immediately after implementing features to help ensure UI consistency and correct behavior.
@@ -266,6 +308,16 @@ After a feature implementation, instruct your AI assistant within its MCP client
 - **Stop Recording:**
   ```
   Stop the current simulator screen recording
+  ```
+
+- **Install App:**
+  ```
+  Install the app at path/to/MyApp.app on the simulator
+  ```
+
+- **Launch App:**
+  ```
+  Launch the Safari app (com.apple.mobilesafari) on the simulator
   ```
 
 ## Prerequisites

--- a/src/index.ts
+++ b/src/index.ts
@@ -829,6 +829,148 @@ if (!isToolFiltered("stop_recording")) {
   );
 }
 
+if (!isToolFiltered("install_app")) {
+  server.tool(
+    "install_app",
+    "Installs an app bundle (.app or .ipa) on the iOS Simulator",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      app_path: z
+        .string()
+        .max(1024)
+        .describe(
+          "Path to the app bundle (.app directory or .ipa file) to install"
+        ),
+    },
+    async ({ udid, app_path }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+        const absolutePath = path.isAbsolute(app_path)
+          ? app_path
+          : path.resolve(app_path);
+
+        // Check if the app bundle exists
+        if (!fs.existsSync(absolutePath)) {
+          throw new Error(`App bundle not found at: ${absolutePath}`);
+        }
+
+        // run() will throw if the command fails (non-zero exit code)
+        await run("xcrun", [
+          "simctl",
+          "install",
+          actualUdid,
+          absolutePath,
+        ]);
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `App installed successfully from: ${absolutePath}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error installing app: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
+if (!isToolFiltered("launch_app")) {
+  server.tool(
+    "launch_app",
+    "Launches an app on the iOS Simulator by bundle identifier",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      bundle_id: z
+        .string()
+        .max(256)
+        .describe(
+          "Bundle identifier of the app to launch (e.g., com.apple.mobilesafari)"
+        ),
+      wait_for_debugger: z
+        .boolean()
+        .optional()
+        .describe("Wait for debugger to attach before launching"),
+      console: z
+        .boolean()
+        .optional()
+        .describe("Attach to the app's stdout/stderr and print to console"),
+      terminate_running: z
+        .boolean()
+        .optional()
+        .describe("Terminate the app if it is already running before launching"),
+    },
+    async ({ udid, bundle_id, wait_for_debugger, console, terminate_running }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        const args = [
+          "simctl",
+          "launch",
+          ...(wait_for_debugger ? ["-w"] : []),
+          ...(console ? ["--console-pty"] : []),
+          ...(terminate_running ? ["--terminate-running-process"] : []),
+          actualUdid,
+          bundle_id,
+        ];
+
+        // run() will throw if the command fails (non-zero exit code)
+        const { stdout } = await run("xcrun", args);
+
+        // Extract PID from output if available
+        // simctl launch outputs the PID as the first token in stdout
+        const pidMatch = stdout.match(/^(\d+)/);
+        const pid = pidMatch ? pidMatch[1] : null;
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: pid
+                ? `App ${bundle_id} launched successfully with PID: ${pid}`
+                : `App ${bundle_id} launched successfully`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error launching app: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
 async function runServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
I added three features to your MCP which allow it to be used for the full lifecycle of app development: `open_simulator`, `install_app`, `launch_app`. With these additional APIs I'm able to utilize your MCP on the other end of a network connection to run the simulator locally while sandboxing the coding enviroment in [sandvault](https://github.com/webcoyote/sandvault) and [clodpod](https://github.com/webcoyote/clodpod). Hope you accept :)

## Summary
- Added `open_simulator` tool to programmatically open the iOS Simulator application
- Added `install_app` tool to install app bundles (.app or .ipa) on the simulator
- Added `launch_app` tool to launch apps by bundle identifier with various options
- Added CLAUDE.md file for AI assistant guidance

## Changes

1. **open_simulator**: Opens the iOS Simulator application using `open -a Simulator`
2. **install_app**: Installs app bundles on the simulator using `xcrun simctl install`
3. **launch_app**: Launches apps with options for console output, debugger wait, and terminate-if-running
4. **Documentation**: Added CLAUDE.md with project overview
