### PR TITLE
docs: update `claude mcp add` command syntax in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Claude Code CLI can manage MCP servers using the `claude mcp` commands or by edi
 1.  Clone this repository, install dependencies, and build the project as described in the Cursor "Local Development" steps 1-3.
 2.  Add the server using the `claude mcp add` command, pointing to your local build:
     ```bash
-    claude mcp add ios-simulator --command node --args "/full/path/to/your/ios-simulator-mcp/build/index.js"
+    claude mcp add ios-simulator -- node "/full/path/to/your/ios-simulator-mcp/build/index.js"
     ```
     **Important:** Replace `/full/path/to/your/` with the absolute path to where you cloned the `ios-simulator-mcp` repository.
 3.  Restart any running Claude Code sessions if necessary.


### PR DESCRIPTION
## Why?

- The claude code mcp command was incorrectly using --command


|Before|After|
|-|-|
|<img width="574" height="77" alt="image" src="https://github.com/user-attachments/assets/d6910fa6-805a-49fd-ba5a-01923d97583f" />|<img width="582" height="52" alt="image" src="https://github.com/user-attachments/assets/a42f3e8f-3919-489d-8607-7e014889bc3a" />|

## Checklist

- [x] I have read and followed the [Contributing Guide](CONTRIBUTING.md)
- [x] I have manually tested this with a real iOS simulator and MCP client (N/A)
- [x] Updated README.md if adding new tools
