### PR TITLE
feat: add ui_find_element tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ The server provides these tools (can be filtered via environment variables):
 - `ui_type` - Input text
 - `ui_swipe` - Swipe gesture
 - `ui_describe_point` - Get element at specific coordinates
+- `ui_find_element` - Search accessibility tree for elements by label, identifier, or type
 - `ui_view` - Get compressed screenshot as base64 JPEG
 - `screenshot` - Save screenshot to file
 - `record_video` - Start video recording

--- a/QA.md
+++ b/QA.md
@@ -12,15 +12,16 @@ You can run a test case copy and pasting the test case into a chat in an MCP cli
 2. Call `get_booted_sim_id` to get the UDID of the booted simulator.
 3. Call `record_video` to start recording a screen recording of the test.
 4. Call `ui_describe_all` to make sure we are on the All Photos tab.
-5. Call `ui_describe_point` to find the x and y coordinates for tapping the Search tab button.
-6. Call `ui_tap` to tap the Search tab button.
-7. Call `ui_tap` to focus on the Search text input.
-8. Call `ui_type` to type "Photos" into the Search text input.
-9. Call `ui_describe_all` to describe the page and find the first photo result.
-10. Call `ui_describe_point` to find the x and y coordinates for the first photo result touchable area.
-11. Call `ui_tap` to tap the coordinates of the first photo result touchable area
-12. Call `ui_swipe` to swipe from the center of the screen down to dismiss the photo and go back to the All Photos tab.
-13. Call `ui_describe_all` to describe the page and see we are the All Photos tab.
-14. Call `screenshot` to take a screenshot of the current page.
-15. Call `ui_view` to view the current page.
-16. Call `stop_recording` to stop the screen recording.
+5. Call `ui_find_element` with `{ "search": ["Search"], "type": "Button" }` to find the Search tab button by its label.
+6. Call `ui_describe_point` to verify the coordinates returned by `ui_find_element` for the Search tab button.
+7. Call `ui_tap` to tap the Search tab button.
+8. Call `ui_tap` to focus on the Search text input.
+9. Call `ui_type` to type "Photos" into the Search text input.
+10. Call `ui_describe_all` to describe the page and find the first photo result.
+11. Call `ui_describe_point` to find the x and y coordinates for the first photo result touchable area.
+12. Call `ui_tap` to tap the coordinates of the first photo result touchable area
+13. Call `ui_swipe` to swipe from the center of the screen down to dismiss the photo and go back to the All Photos tab.
+14. Call `ui_describe_all` to describe the page and see we are the All Photos tab.
+15. Call `screenshot` to take a screenshot of the current page.
+16. Call `ui_view` to view the current page.
+17. Call `stop_recording` to stop the screen recording.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,30 @@ This project has been featured and mentioned in various publications and resourc
 }
 ```
 
+### `ui_find_element`
+
+**Description:** Searches the accessibility tree and returns elements matching the given criteria
+
+**Parameters:**
+
+```typescript
+{
+  /** Array of search strings. An element matches if ANY string matches against its AXLabel or AXUniqueId */
+  search: string[];
+  /** Filter by element type (e.g. 'Button', 'StaticText', 'Group'). Case-insensitive exact match */
+  type?: string;
+  /** Match mode: 'substring' (default) or 'exact' */
+  matchMode?: "substring" | "exact";
+  /** Whether search matching is case-sensitive (default: false) */
+  caseSensitive?: boolean;
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+}
+```
+
 ### `ui_view`
 
 **Description:** Get the image content of a compressed screenshot of the current simulator view

--- a/src/index.ts
+++ b/src/index.ts
@@ -515,6 +515,131 @@ if (!isToolFiltered("ui_describe_point")) {
   );
 }
 
+if (!isToolFiltered("ui_find_element")) {
+  server.tool(
+    "ui_find_element",
+    "Searches the accessibility tree and returns elements matching the given criteria",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      search: z
+        .array(z.string().min(1))
+        .min(1)
+        .describe(
+          "Array of search strings. An element matches if ANY string matches against its AXLabel or AXUniqueId"
+        ),
+      type: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by element type (e.g. 'Button', 'StaticText', 'Group'). Case-insensitive exact match"
+        ),
+      matchMode: z
+        .enum(["substring", "exact"])
+        .optional()
+        .default("substring")
+        .describe("Match mode for search strings: 'substring' (default) or 'exact'"),
+      caseSensitive: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Whether search matching is case-sensitive (default: false)"),
+    },
+    { title: "Find UI Element", readOnlyHint: true, openWorldHint: true },
+    async ({ search, type, matchMode, caseSensitive, udid }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        const { stdout } = await idb(
+          "ui",
+          "describe-all",
+          "--udid",
+          actualUdid,
+          "--json",
+          "--nested"
+        );
+
+        const uiData = JSON.parse(stdout);
+
+        function matchesSearch(
+          value: string | null,
+          term: string,
+          mode: "substring" | "exact",
+          sensitive: boolean
+        ): boolean {
+          if (value == null) return false;
+          const v = sensitive ? value : value.toLowerCase();
+          const t = sensitive ? term : term.toLowerCase();
+          return mode === "exact" ? v === t : v.includes(t);
+        }
+
+        function findElements(
+          elements: Array<Record<string, unknown>>
+        ): Array<Record<string, unknown>> {
+          const results: Array<Record<string, unknown>> = [];
+
+          for (const element of elements) {
+            const label = element.AXLabel as string | null;
+            const uniqueId = element.AXUniqueId as string | null;
+            const elementType = element.type as string | undefined;
+
+            const matchesAnySearch = search.some(
+              (term) =>
+                matchesSearch(label, term, matchMode, caseSensitive) ||
+                matchesSearch(uniqueId, term, matchMode, caseSensitive)
+            );
+
+            const matchesType =
+              type == null ||
+              (elementType != null &&
+                elementType.toLowerCase() === type.toLowerCase());
+
+            if (matchesAnySearch && matchesType) {
+              results.push(element);
+            }
+
+            const children = element.children as
+              | Array<Record<string, unknown>>
+              | undefined;
+            if (children && children.length > 0) {
+              results.push(...findElements(children));
+            }
+          }
+
+          return results;
+        }
+
+        const results = findElements(uiData);
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(results),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error finding UI elements: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
 if (!isToolFiltered("ui_view")) {
   server.tool(
     "ui_view",


### PR DESCRIPTION
## Summary

- Add `ui_find_element` MCP tool that searches the accessibility tree and returns matching elements
- Supports search by `AXLabel` and `AXUniqueId` with configurable match mode and case sensitivity

## Motivation

Currently, to find a specific UI element, an agent must call `ui_describe_all` which returns the **entire** accessibility tree. On a typical screen this can be hundreds of elements, quickly consuming the agent's context window. `ui_find_element` lets the agent query for specific elements (e.g. "find the Login button") and get back only what matches — dramatically reducing token usage and making agent loops more efficient.

**Real use case:** An AI agent automating an iOS app needs to tap a button but doesn't know its coordinates. Today it must: `ui_describe_all` (huge response) -> parse the tree -> find the element -> extract coordinates. With `ui_find_element`: one call with `{ "search": ["Login"], "type": "Button" }` returns just the matching element with its frame coordinates.

## Test Plan

Tested on iPhone 16 Pro, iOS 18.5 with the Settings app.

1. Checkout this PR
2. Follow [Local Development Guide](https://github.com/joshuayoes/ios-simulator-mcp?tab=readme-ov-file#option-2-local-development) to setup locally in your MCP client
3. Make sure an iOS Simulator is open with the Settings app
4. In your MCP client, give the prompt "Use ui_find_element to find a button labeled General". Verify the tool returns exactly one element — the General settings button with its coordinates.
5. Give the prompt "Use ui_find_element to find all elements containing Screen". Verify it returns two elements: "Home Screen & App Library" and "Screen Time".
6. Give the prompt "Use ui_find_element to search for general (lowercase) with exact match mode and case sensitivity enabled". Verify it returns no results since the actual label is "General" with a capital G.
7. Give the prompt "Use ui_find_element to search for NONEXISTENT_ELEMENT". Verify it returns an empty array without error.

**Note:** On iOS 26.2, the Photos app no longer exposes Tab Bar buttons in the accessibility tree. This affects the existing QA.md test case (step 5 onwards) as well as any test relying on the Search tab button. The QA.md test case works on iOS 17.2 and iOS 18.5.

## Demo

as you can see above server found explicitly described cells with text and implicitly (with accessibility identifier) back button with just icon

https://github.com/user-attachments/assets/d108eefe-9784-4560-9048-aab67e9769a5