### PR TITLE
Rename booted sim tool and return all booted simulators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the iOS Simulator MCP (Model Context Protocol) server - a tool that enables AI assistants to interact with iOS simulators through MCP. The project follows an **intentionally simple** single-file architecture where all logic is contained in `src/index.ts`.
+
+## Build and Development Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Build the TypeScript project (compiles to build/)
+npm run build
+
+# Development with automatic rebuild on changes
+npm run watch
+
+# Run the MCP inspector for testing
+npm run dev
+
+# Start the compiled server
+npm start
+```
+
+## Architecture
+
+The entire server implementation is in `src/index.ts` (single file by design). The server:
+- Uses the MCP SDK to expose tools for iOS simulator interaction
+- Wraps `xcrun simctl` and Facebook's `idb` commands
+- Validates all inputs with Zod schemas
+- Implements security best practices with `--` argument separation
+- Supports environment-based tool filtering via `IOS_SIMULATOR_MCP_FILTERED_TOOLS`
+- Handles output paths with `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` environment variable
+
+## Available MCP Tools
+
+The server provides these tools (can be filtered via environment variables):
+- `get_booted_sim_id` - Get the currently booted simulator ID
+- `open_simulator` - Open the iOS Simulator application
+- `ui_describe_all` - Get accessibility info for the entire screen
+- `ui_tap` - Tap at coordinates
+- `ui_type` - Input text
+- `ui_swipe` - Swipe gesture
+- `ui_describe_point` - Get element at specific coordinates
+- `ui_view` - Get compressed screenshot as base64 JPEG
+- `screenshot` - Save screenshot to file
+- `record_video` - Start video recording
+- `stop_recording` - Stop video recording
+- `install_app` - Install an app bundle (.app or .ipa) on the simulator
+- `launch_app` - Launch an app by bundle identifier
+
+## Testing
+
+This project requires **manual testing** on macOS with:
+- Xcode and iOS simulators installed
+- Facebook IDB tool installed
+- An MCP client (like Cursor) configured to use the server
+
+Test changes by:
+1. Building with `npm run build`
+2. Configuring your MCP client to point to `build/index.js`
+3. Running through the test cases in `QA.md`
+
+## Important Design Principles
+
+- **Keep it simple**: Single file, minimal dependencies, standard tooling (npm/tsc)
+- **Real use cases only**: Don't add hypothetical features
+- **Security first**: Always use `--` separator for user inputs, validate with Zod
+- **No architecture changes** without discussion - the single-file design is intentional
+
+## Additional Documentation
+
+For more detailed information, refer to these documentation files:
+
+- **[README.md](README.md)** - Complete project documentation including installation instructions, available tools, configuration options, and usage examples
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contribution guidelines, development setup, dependency management, and the project's philosophy of intentional simplicity
+- **[QA.md](QA.md)** - Manual quality assurance test cases for validating functionality
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Common issues and their solutions, including IDB installation help
+- **[SECURITY.md](SECURITY.md)** - Security policy and information about fixed vulnerabilities
+- **[CONTEXT.md](CONTEXT.md)** - Reference links for MCP documentation, iOS simulator commands, IDB commands, and security best practices

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The entire server implementation is in `src/index.ts` (single file by design). T
 ## Available MCP Tools
 
 The server provides these tools (can be filtered via environment variables):
-- `get_booted_sim_id` - Get the currently booted simulator ID
+- `get_booted_sim_ids` - Get the ids and names of all currently booted simulators
 - `open_simulator` - Open the iOS Simulator application
 - `ui_describe_all` - Get accessibility info for the entire screen
 - `ui_tap` - Tap at coordinates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ The entire server implementation is in `src/index.ts` (single file by design). T
 ## Available MCP Tools
 
 The server provides these tools (can be filtered via environment variables):
-- `get_booted_sim_id` - Get the currently booted simulator ID
+- `get_booted_sim_ids` - Get the ids and names of all currently booted simulators
 - `open_simulator` - Open the iOS Simulator application
 - `ui_describe_all` - Get accessibility info for the entire screen
 - `ui_tap` - Tap at coordinates

--- a/QA.md
+++ b/QA.md
@@ -9,7 +9,7 @@ You can run a test case copy and pasting the test case into a chat in an MCP cli
 **Note:** This test case was written using iOS 17.2 and the native Photos app. It may need to be adjusted for other iOS versions or Photos app changes.
 
 1. Have the user open the native Photo app in the iOS simulator.
-2. Call `get_booted_sim_id` to get the UDID of the booted simulator.
+2. Call `get_booted_sim_ids` to get the names and UDIDs of the booted simulators, then use the simulator under test.
 3. Call `record_video` to start recording a screen recording of the test.
 4. Call `ui_describe_all` to make sure we are on the All Photos tab.
 5. Call `ui_describe_point` to find the x and y coordinates for tapping the Search tab button.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ This project has been featured and mentioned in various publications and resourc
 
 ## Tools
 
-### `get_booted_sim_id`
+### `get_booted_sim_ids`
 
-**Description:** Get the ID of the currently booted iOS simulator
+**Description:** Get the IDs and names of all currently booted iOS simulators
 
 **Parameters:** No Parameters
+
+**Returns:** A JSON array of booted simulators, each with `id` and `name`
 
 ### `open_simulator`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,29 +113,59 @@ function errorWithTroubleshooting(message: string): string {
   return `${message}\n\nFor help, see the ${troubleshootingLink()}`;
 }
 
-async function getBootedDevice() {
-  const { stdout, stderr } = await run("xcrun", ["simctl", "list", "devices"]);
+type BootedDevice = {
+  id: string;
+  name: string;
+};
+
+type SimctlDevice = {
+  name?: string;
+  state?: string;
+  udid?: string;
+};
+
+type SimctlListDevicesResponse = {
+  devices?: Record<string, SimctlDevice[]>;
+};
+
+function isBootedDevice(
+  device: SimctlDevice
+): device is SimctlDevice & { name: string; state: "Booted"; udid: string } {
+  return (
+    device.state === "Booted" &&
+    typeof device.name === "string" &&
+    typeof device.udid === "string"
+  );
+}
+
+async function getBootedDevices(): Promise<BootedDevice[]> {
+  const { stdout, stderr } = await run("xcrun", [
+    "simctl",
+    "list",
+    "devices",
+    "--json",
+  ]);
 
   if (stderr) throw new Error(stderr);
 
-  // Parse the output to find booted device
-  const lines = stdout.split("\n");
-  for (const line of lines) {
-    if (line.includes("Booted")) {
-      // Extract the UUID - it's inside parentheses
-      const match = line.match(/\(([-0-9A-F]+)\)/);
-      if (match) {
-        const deviceId = match[1];
-        const deviceName = line.split("(")[0].trim();
-        return {
-          name: deviceName,
-          id: deviceId,
-        };
-      }
-    }
+  const devices = (JSON.parse(stdout) as SimctlListDevicesResponse).devices ?? {};
+  const bootedDevices = Object.values(devices)
+    .flat()
+    .filter(isBootedDevice)
+    .map((device) => ({
+      name: device.name,
+      id: device.udid,
+    }));
+
+  if (bootedDevices.length === 0) {
+    throw Error("No booted simulator found");
   }
 
-  throw Error("No booted simulator found");
+  return bootedDevices;
+}
+
+async function getBootedDevice(): Promise<BootedDevice> {
+  return (await getBootedDevices())[0];
 }
 
 async function getBootedDeviceId(
@@ -154,21 +184,25 @@ async function getBootedDeviceId(
 }
 
 // Register tools only if they're not filtered
-if (!isToolFiltered("get_booted_sim_id")) {
+if (!isToolFiltered("get_booted_sim_ids")) {
   server.tool(
-    "get_booted_sim_id",
-    "Get the ID of the currently booted iOS simulator",
-    { title: "Get Booted Simulator ID", readOnlyHint: true, openWorldHint: true },
+    "get_booted_sim_ids",
+    "Get the IDs and names of all currently booted iOS simulators",
+    {
+      title: "Get Booted Simulator IDs",
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
     async () => {
       try {
-        const { id, name } = await getBootedDevice();
+        const bootedDevices = await getBootedDevices();
 
         return {
           isError: false,
           content: [
             {
               type: "text",
-              text: `Booted Simulator: "${name}". UUID: "${id}"`,
+              text: JSON.stringify(bootedDevices, null, 2),
             },
           ],
         };


### PR DESCRIPTION
## Why
The current `get_booted_sim_id` tool only returns the first booted simulator, which breaks down when multiple simulators are running. This change makes the tool name and output match real `simctl` behavior.

## What
- Rename the tool to `get_booted_sim_ids`
- Parse `xcrun simctl list devices --json` and return every booted simulator's `id` and `name`
- Update README, QA guidance, and agent docs to reflect the new tool and output

## Risk Assessment
Low - this is a targeted change to one read-only MCP tool plus documentation, and the project builds cleanly after the update.

## References
- Validation: `npm run build`
- Sanity check: `xcrun simctl list devices --json` returned two booted simulators on this machine, and the new mapping produced both entries

Generated with Codex