### PR TITLE
feat: add terminate_app, open_url, and list_apps tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,9 @@ The server provides these tools (can be filtered via environment variables):
 - `stop_recording` - Stop video recording
 - `install_app` - Install an app bundle (.app or .ipa) on the simulator
 - `launch_app` - Launch an app by bundle identifier
+- `terminate_app` - Terminate a running app by bundle identifier
+- `open_url` - Open a URL or deep link in the simulator
+- `list_apps` - List all installed apps with their bundle IDs and display names
 
 ## Testing
 

--- a/QA.md
+++ b/QA.md
@@ -25,3 +25,14 @@ You can run a test case copy and pasting the test case into a chat in an MCP cli
 15. Call `screenshot` to take a screenshot of the current page.
 16. Call `ui_view` to view the current page.
 17. Call `stop_recording` to stop the screen recording.
+
+## Test Case: App Lifecycle (terminate_app, open_url, list_apps)
+
+**Note:** Assumes at least one simulator is booted.
+
+1. Call `get_booted_sim_id` to get the UDID of the booted simulator.
+2. Call `list_apps` and confirm the response includes at least Safari (`com.apple.mobilesafari`) along with other system apps, sorted alphabetically by display name.
+3. Call `open_url` with `https://example.com` and confirm Safari launches and loads the page.
+4. Call `terminate_app` with `com.apple.mobilesafari` and confirm Safari is no longer running (Safari window closes / home screen is shown).
+5. Call `open_url` with a custom-scheme deep link for an app you have installed (e.g. `maps://?q=Apple+Park`) and confirm the correct app opens.
+6. Call `terminate_app` with a bogus bundle ID (e.g. `com.does.not.exist`) and confirm a friendly error message is returned.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,58 @@ This project has been featured and mentioned in various publications and resourc
 }
 ```
 
+### `terminate_app`
+
+**Description:** Terminates a running app on the iOS Simulator by bundle identifier. Useful for testing cold-start flows and verifying crash recovery without reinstalling the app.
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+  /** Bundle identifier of the app to terminate (e.g., com.apple.mobilesafari) */
+  bundle_id: string;
+}
+```
+
+### `open_url`
+
+**Description:** Opens a URL or deep link in the iOS Simulator. Handles `https://` URLs (via Safari), custom URL schemes, and universal links — essential for testing deep-link routing and OAuth redirect flows.
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+  /** The URL or deep link to open (e.g., https://example.com or myapp://screen/detail) */
+  url: string;
+}
+```
+
+### `list_apps`
+
+**Description:** Lists all installed apps on the iOS Simulator with their bundle identifiers and display names, sorted alphabetically. Removes the need to look up bundle IDs manually before calling `launch_app` or `terminate_app`.
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+}
+```
+
 ## 💡 Use Case: QA Step via MCP Tool Calls
 
 This MCP server allows AI assistants integrated with a Model Context Protocol (MCP) client to perform Quality Assurance tasks by making tool calls. This is useful immediately after implementing features to help ensure UI consistency and correct behavior.

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,41 @@ async function run(
 }
 
 /**
+ * Runs a command with arguments, pipes `stdin` to it, and returns the stdout and stderr.
+ * Used when we need to feed the output of one command into another without going through a shell.
+ */
+async function runWithStdin(
+  cmd: string,
+  args: string[],
+  stdin: string
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { shell: false });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${cmd} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`
+          )
+        );
+      } else {
+        resolve({ stdout: stdout.trim(), stderr: stderr.trim() });
+      }
+    });
+    child.stdin.end(stdin);
+  });
+}
+
+/**
  * Gets the IDB command path from environment variable or defaults to "idb"
  * @returns The path to the IDB executable
  * @throws Error if custom path is specified but doesn't exist
@@ -1257,6 +1292,7 @@ if (!isToolFiltered("terminate_app")) {
           "simctl",
           "terminate",
           actualUdid,
+          "--",
           bundle_id,
         ]);
 
@@ -1310,6 +1346,7 @@ if (!isToolFiltered("open_url")) {
           "simctl",
           "openurl",
           actualUdid,
+          "--",
           url,
         ]);
 
@@ -1355,33 +1392,34 @@ if (!isToolFiltered("list_apps")) {
       try {
         const actualUdid = await getBootedDeviceId(udid);
 
-        const { stdout } = await run("xcrun", [
+        const { stdout: plistText } = await run("xcrun", [
           "simctl",
           "listapps",
           actualUdid,
         ]);
 
-        // Parse the plist output to extract bundle ID and display name
-        const apps: { bundleId: string; name: string }[] = [];
-        const bundleIdMatches = stdout.matchAll(/"([^"]+)" = \{/g);
+        // `simctl listapps` emits NeXTSTEP-style plist text that varies in
+        // whitespace across Xcode versions. Delegate parsing to `plutil` which
+        // converts it to JSON regardless of formatting quirks.
+        const { stdout: jsonText } = await runWithStdin(
+          "plutil",
+          ["-convert", "json", "-o", "-", "--", "-"],
+          plistText
+        );
 
-        for (const match of bundleIdMatches) {
-          const bundleId = match[1];
-          // Find the display name for this bundle
-          const blockStart = stdout.indexOf(match[0]);
-          const blockEnd = stdout.indexOf("\n    };", blockStart);
-          const block = stdout.slice(blockStart, blockEnd);
+        const rawApps = JSON.parse(jsonText) as Record<
+          string,
+          { CFBundleDisplayName?: string; CFBundleName?: string }
+        >;
 
-          const nameMatch =
-            block.match(/CFBundleDisplayName = "([^"]+)"/) ||
-            block.match(/CFBundleName = "([^"]+)"/);
-
-          const name = nameMatch ? nameMatch[1] : bundleId;
-          apps.push({ bundleId, name });
-        }
+        const apps = Object.entries(rawApps)
+          .map(([bundleId, info]) => ({
+            bundleId,
+            name: info.CFBundleDisplayName ?? info.CFBundleName ?? bundleId,
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name));
 
         const appList = apps
-          .sort((a, b) => a.name.localeCompare(b.name))
           .map((a) => `${a.name} — ${a.bundleId}`)
           .join("\n");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1233,6 +1233,184 @@ if (!isToolFiltered("launch_app")) {
   );
 }
 
+if (!isToolFiltered("terminate_app")) {
+  server.tool(
+    "terminate_app",
+    "Terminates a running app on the iOS Simulator by bundle identifier",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      bundle_id: z
+        .string()
+        .max(256)
+        .describe("Bundle identifier of the app to terminate (e.g., com.apple.mobilesafari)"),
+    },
+    { title: "Terminate App", readOnlyHint: false, openWorldHint: true },
+    async ({ udid, bundle_id }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        await run("xcrun", [
+          "simctl",
+          "terminate",
+          actualUdid,
+          bundle_id,
+        ]);
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `App ${bundle_id} terminated successfully`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error terminating app: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
+if (!isToolFiltered("open_url")) {
+  server.tool(
+    "open_url",
+    "Opens a URL in the iOS Simulator, useful for testing deep links and universal links",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      url: z
+        .string()
+        .max(2048)
+        .describe("The URL or deep link to open (e.g., https://example.com or myapp://screen/detail)"),
+    },
+    { title: "Open URL", readOnlyHint: false, openWorldHint: true },
+    async ({ udid, url }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        await run("xcrun", [
+          "simctl",
+          "openurl",
+          actualUdid,
+          url,
+        ]);
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `Opened URL: ${url}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error opening URL: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
+if (!isToolFiltered("list_apps")) {
+  server.tool(
+    "list_apps",
+    "Lists all installed apps on the iOS Simulator with their bundle identifiers and display names",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+    },
+    { title: "List Installed Apps", readOnlyHint: true, openWorldHint: true },
+    async ({ udid }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        const { stdout } = await run("xcrun", [
+          "simctl",
+          "listapps",
+          actualUdid,
+        ]);
+
+        // Parse the plist output to extract bundle ID and display name
+        const apps: { bundleId: string; name: string }[] = [];
+        const bundleIdMatches = stdout.matchAll(/"([^"]+)" = \{/g);
+
+        for (const match of bundleIdMatches) {
+          const bundleId = match[1];
+          // Find the display name for this bundle
+          const blockStart = stdout.indexOf(match[0]);
+          const blockEnd = stdout.indexOf("\n    };", blockStart);
+          const block = stdout.slice(blockStart, blockEnd);
+
+          const nameMatch =
+            block.match(/CFBundleDisplayName = "([^"]+)"/) ||
+            block.match(/CFBundleName = "([^"]+)"/);
+
+          const name = nameMatch ? nameMatch[1] : bundleId;
+          apps.push({ bundleId, name });
+        }
+
+        const appList = apps
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((a) => `${a.name} — ${a.bundleId}`)
+          .join("\n");
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: appList || "No apps found",
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error listing apps: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
 async function runServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## Summary

Three new tools covering common QA workflows that previously required manually running `xcrun simctl` commands outside the MCP server.

### `terminate_app`
Kills a running app by bundle identifier without relaunching it. Useful for:
- Testing cold-start vs warm-start behaviour
- Resetting app state between test runs
- Testing crash recovery flows

### `open_url`
Opens any URL or deep link in the simulator. Useful for:
- Testing custom URL schemes (e.g. `myapp://profile/123`)
- Testing universal links
- Testing OAuth redirect flows after external authentication

### `list_apps`
Lists all installed apps with their bundle IDs and display names, sorted alphabetically. Useful for:
- Discovering bundle IDs before calling `launch_app` or `terminate_app`
- Verifying an app was installed correctly
- Auditing what's installed on the simulator

## Test Plan

- [ ] `terminate_app` with a running app — confirm it stops, relaunch works after
- [ ] `terminate_app` with an app that isn't running — confirm graceful error
- [ ] `open_url` with `https://` URL — confirm Safari opens the page
- [ ] `open_url` with a custom deep link — confirm correct app handles it
- [ ] `list_apps` — confirm output lists installed apps with correct bundle IDs