### PR TITLE
chore: align deps with SDK 1.29.0 and document record_video udid

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ This project has been featured and mentioned in various publications and resourc
 
 ```typescript
 {
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
   /** Optional output path. If not provided, a default name will be used. The file will be saved in the directory specified by `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` or in `~/Downloads` if the environment variable is not set. */
   output_path?: string;
   /** Specifies the codec type: "h264" or "hevc". Default is "hevc". */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25.0"
       },
       "bin": {
         "ios-simulator-mcp": "build/index.js"
       },
       "devDependencies": {
         "@modelcontextprotocol/inspector": "0.16.8",
-        "@types/node": "^22.0.2",
+        "@types/node": "^22.12.0",
         "typescript": "^5.5.4"
       }
     },
@@ -1173,6 +1173,7 @@
       "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1847,6 +1848,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2121,6 +2123,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2641,6 +2644,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2654,6 +2658,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3229,6 +3234,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3465,6 +3471,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "zod": "^3.23.8"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "0.16.8",
-    "@types/node": "^22.0.2",
+    "@types/node": "^22.12.0",
     "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
## Summary

Small follow-up to #59:

1. **Document the new `udid` param on `record_video`** in `README.md`. The schema was added in #59 but the docs weren't updated.
2. **Align declared dep ranges with SDK 1.29.0** per the policy in `CONTRIBUTING.md` → "Dependency Management":
   - `zod: ^3.23.8` → `^3.25.0` (SDK peer range is `^3.25 || ^4.0`)
   - `@types/node: ^22.0.2` → `^22.12.0` (SDK devDep is `^22.12.0`)

Resolved versions don't change — `zod` stays at `3.25.76`, `@types/node` stays at `22.13.5`. This is purely declared-range hygiene so our `package.json` is honest about what we need. Fresh `npm install` still reports 0 vulnerabilities.

## Test plan

- [x] `npm install` succeeds without peer warnings
- [x] `npm run build` compiles cleanly
- [x] `npm ls zod` shows `3.25.76` deduped across SDK + inspector
- [x] `npm audit` reports 0 vulnerabilities
- [ ] Manual QA not required — no runtime code changes