### PR TITLE
docs: compress demo video (100MB → 6MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Model Context Protocol (MCP) server for interacting with iOS simulators. This 
 
 > **Security Notice**: Command injection vulnerabilities present in versions < 1.3.3 have been fixed. Please update to v1.3.3 or later. See [SECURITY.md](SECURITY.md) for details.
 
-demo.mp4
+<video src="demo.mp4" width="100%" controls autoplay loop muted></video>
 
 ## 🌟 Featured In
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Model Context Protocol (MCP) server for interacting with iOS simulators. This 
 
 > **Security Notice**: Command injection vulnerabilities present in versions < 1.3.3 have been fixed. Please update to v1.3.3 or later. See [SECURITY.md](SECURITY.md) for details.
 
-https://github.com/user-attachments/assets/453ebe7b-cc93-4ac2-b08d-0f8ac8339ad3
+https://github.com/user-attachments/assets/802a39a5-49f1-4160-b7fb-1c95ca914571
 
 ## 🌟 Featured In
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
   
 # iOS Simulator MCP Server
 
-<video src="demo.mp4" width="100%" controls autoplay loop muted></video>
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=ios-simulator&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImlvcy1zaW11bGF0b3ItbWNwIl19) [![NPM Version](https://img.shields.io/npm/v/ios-simulator-mcp)](https://www.npmjs.com/package/ios-simulator-mcp)
 
 A Model Context Protocol (MCP) server for interacting with iOS simulators. This server allows you to interact with iOS simulators by getting information about them, controlling UI interactions, and inspecting UI elements.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
   
 # iOS Simulator MCP Server
 
-<video src="demo.mp4" width="100%" controls autoplay loop muted>
-
+<video src="demo.mp4" width="100%" controls autoplay loop muted></video>
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=ios-simulator&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImlvcy1zaW11bGF0b3ItbWNwIl19) [![NPM Version](https://img.shields.io/npm/v/ios-simulator-mcp)](https://www.npmjs.com/package/ios-simulator-mcp)
 
 A Model Context Protocol (MCP) server for interacting with iOS simulators. This server allows you to interact with iOS simulators by getting information about them, controlling UI interactions, and inspecting UI elements.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Model Context Protocol (MCP) server for interacting with iOS simulators. This 
 
 > **Security Notice**: Command injection vulnerabilities present in versions < 1.3.3 have been fixed. Please update to v1.3.3 or later. See [SECURITY.md](SECURITY.md) for details.
 
-https://github.com/user-attachments/assets/802a39a5-49f1-4160-b7fb-1c95ca914571
+demo.mp4
 
 ## 🌟 Featured In
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Model Context Protocol (MCP) server for interacting with iOS simulators. This 
 
 > **Security Notice**: Command injection vulnerabilities present in versions < 1.3.3 have been fixed. Please update to v1.3.3 or later. See [SECURITY.md](SECURITY.md) for details.
 
-[demo.mp4](https://github.com/user-attachments/assets/a88e449c-8f1d-46a5-9816-0f97e071c460)
+https://github.com/user-attachments/assets/a88e449c-8f1d-46a5-9816-0f97e071c460
 
 ## 🌟 Featured In
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
-<video src="demo.mp4" width="100%" controls autoplay loop muted>
   
 # iOS Simulator MCP Server
+
+<video src="demo.mp4" width="100%" controls autoplay loop muted>
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=ios-simulator&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImlvcy1zaW11bGF0b3ItbWNwIl19) [![NPM Version](https://img.shields.io/npm/v/ios-simulator-mcp)](https://www.npmjs.com/package/ios-simulator-mcp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-https://github.com/user-attachments/assets/a88e449c-8f1d-46a5-9816-0f97e071c460
 
 
 # iOS Simulator MCP Server
@@ -10,7 +9,7 @@ A Model Context Protocol (MCP) server for interacting with iOS simulators. This 
 
 > **Security Notice**: Command injection vulnerabilities present in versions < 1.3.3 have been fixed. Please update to v1.3.3 or later. See [SECURITY.md](SECURITY.md) for details.
 
-<video src="demo.mp4" width="100%" controls autoplay loop muted></video>
+[demo.mp4](https://github.com/user-attachments/assets/a88e449c-8f1d-46a5-9816-0f97e071c460)
 
 ## 🌟 Featured In
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+https://github.com/user-attachments/assets/a88e449c-8f1d-46a5-9816-0f97e071c460
+
+
 # iOS Simulator MCP Server
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=ios-simulator&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImlvcy1zaW11bGF0b3ItbWNwIl19) [![NPM Version](https://img.shields.io/npm/v/ios-simulator-mcp)](https://www.npmjs.com/package/ios-simulator-mcp)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-  
 # iOS Simulator MCP Server
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=ios-simulator&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImlvcy1zaW11bGF0b3ItbWNwIl19) [![NPM Version](https://img.shields.io/npm/v/ios-simulator-mcp)](https://www.npmjs.com/package/ios-simulator-mcp)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-
-
+<video src="demo.mp4" width="100%" controls autoplay loop muted>
+  
 # iOS Simulator MCP Server
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=ios-simulator&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImlvcy1zaW11bGF0b3ItbWNwIl19) [![NPM Version](https://img.shields.io/npm/v/ios-simulator-mcp)](https://www.npmjs.com/package/ios-simulator-mcp)


### PR DESCRIPTION
The demo video in the README is a ~100MB uncompressed MOV file, which causes slow page loads for everyone who visits the repo.

## Changes

- Converted MOV → MP4 with `-movflags faststart` (moov atom at file start, enables playback before full download)
- Stripped empty audio track (original had no audio data)
- **~100MB → 6MB**, no visible quality loss

## Note on video hosting

The compressed video is referenced via a GitHub `user-attachments` URL — the same approach as the original. If the embedded player appears flaky on your end, I can switch to committing the file directly to the repo (`demo.mp4`, 6MB). Left a comment below with more detail.
