### PR TITLE
docs: add deep link navigation tip using uri-scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,38 @@ After a feature implementation, instruct your AI assistant within its MCP client
   Launch the Safari app (com.apple.mobilesafari) on the simulator
   ```
 
+## 🧭 Tip: Deep Link Straight to a Screen
+
+Agents can waste a lot of iterations tapping and swiping their way to a deeply
+nested route. When your app registers a URL scheme (or Universal Link), it's
+usually faster to jump directly to the target screen instead of navigating there
+step by step.
+
+You can open a deep link with [`uri-scheme`](https://www.npmjs.com/package/uri-scheme):
+
+```bash
+npx uri-scheme open "myapp://products/42" --ios
+```
+
+This targets the currently booted simulator. Under the hood it's equivalent to:
+
+```bash
+xcrun simctl openurl booted "myapp://products/42"
+```
+
+Both work for custom schemes (`myapp://...`) and web URLs (`https://...`, which
+trigger Universal Links if your app is configured for them).
+
+**Example prompt:**
+
+```
+Open the deep link myapp://products/42 in the simulator, then verify the product
+details screen is shown
+```
+
+Use this to shorten agent loops: deep link to the screen under test, then use the
+UI tools (`ui_describe_all`, `ui_tap`, `ui_view`, …) to validate it.
+
 ## Prerequisites
 
 - Node.js


### PR DESCRIPTION
## Summary

Adds a short guide (requested in #26) on jumping straight to a screen via a deep link instead of tapping/swiping through nested routes — a common source of wasted agent iterations.

Documents both `npx uri-scheme open "myapp://route" --ios` and the equivalent `xcrun simctl openurl booted <url>`, covering custom schemes and Universal Links, with an example prompt that ties it into the existing UI validation tools.

Docs-only change, no code touched. Both commands verified against a booted simulator (iPhone 17 / iOS 26.5).

Closes #26