### PR TITLE
feat: add terminate_app, open_url, and list_apps tools (supersedes #61)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,9 @@ The server provides these tools (can be filtered via environment variables):
 - `stop_recording` - Stop video recording
 - `install_app` - Install an app bundle (.app or .ipa) on the simulator
 - `launch_app` - Launch an app by bundle identifier
+- `terminate_app` - Terminate a running app by bundle identifier
+- `open_url` - Open a URL or deep link in the simulator
+- `list_apps` - List all installed apps with their bundle IDs and display names
 
 ## Testing
 

--- a/QA.md
+++ b/QA.md
@@ -35,3 +35,12 @@ installed.
 A pass is: every call returns without `isError`, the taps land where the
 find/describe steps said they would, and the screenshot/video artifacts exist
 and show the run. Anything else is a finding — file it.
+
+## App lifecycle scenario (terminate_app, open_url, list_apps)
+
+1. Call `get_booted_sim_id` and note the UDID.
+2. Call `list_apps` and confirm the response includes at least Safari (`com.apple.mobilesafari`) along with other system apps, sorted alphabetically by display name.
+3. Call `open_url` with `https://example.com` and confirm Safari launches and loads the page.
+4. Call `terminate_app` with `com.apple.mobilesafari` and confirm Safari is no longer running (relaunching Safari via `launch_app` should cold-start it).
+5. Call `open_url` with a custom-scheme deep link for an app on the simulator (e.g. `maps://?q=Apple+Park`) and confirm the correct app opens.
+6. Call `terminate_app` with the same bundle id again (app no longer running) and confirm a graceful error mentioning simctl's "found nothing to terminate".

--- a/README.md
+++ b/README.md
@@ -293,6 +293,58 @@ This project has been featured and mentioned in various publications and resourc
 }
 ```
 
+### `terminate_app`
+
+**Description:** Terminates a running app on the iOS Simulator by bundle identifier. Useful for testing cold-start flows and verifying crash recovery without reinstalling the app.
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+  /** Bundle identifier of the app to terminate (e.g., com.apple.mobilesafari) */
+  bundle_id: string;
+}
+```
+
+### `open_url`
+
+**Description:** Opens a URL or deep link in the iOS Simulator. Handles `https://` URLs (via Safari), custom URL schemes, and universal links — essential for testing deep-link routing and OAuth redirect flows.
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+  /** The URL or deep link to open (e.g., https://example.com or myapp://screen/detail) */
+  url: string;
+}
+```
+
+### `list_apps`
+
+**Description:** Lists all installed apps on the iOS Simulator with their bundle identifiers and display names, sorted alphabetically. Removes the need to look up bundle IDs manually before calling `launch_app` or `terminate_app`.
+
+**Parameters:**
+
+```typescript
+{
+  /**
+   * Udid of target, can also be set with the IDB_UDID env var
+   * Format: UUID (8-4-4-4-12 hexadecimal characters)
+   */
+  udid?: string;
+}
+```
+
 ## 💡 Use Case: QA Step via MCP Tool Calls
 
 This MCP server allows AI assistants integrated with a Model Context Protocol (MCP) client to perform Quality Assurance tasks by making tool calls. This is useful immediately after implementing features to help ensure UI consistency and correct behavior.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1399,21 +1399,32 @@ if (!isToolFiltered("launch_app")) {
 }
 
 if (!isToolFiltered("terminate_app")) {
-  server.tool(
+  server.registerTool(
     "terminate_app",
-    "Terminates a running app on the iOS Simulator by bundle identifier",
     {
-      udid: z
-        .string()
-        .regex(UDID_REGEX)
-        .optional()
-        .describe("Udid of target, can also be set with the IDB_UDID env var"),
-      bundle_id: z
-        .string()
-        .max(256)
-        .describe("Bundle identifier of the app to terminate (e.g., com.apple.mobilesafari)"),
+      description:
+        "Terminates a running app on the iOS Simulator by bundle identifier",
+      inputSchema: z.object({
+        udid: z
+          .string()
+          .regex(UDID_REGEX)
+          .optional()
+          .describe(
+            "Udid of target, can also be set with the IDB_UDID env var",
+          ),
+        bundle_id: z
+          .string()
+          .max(256)
+          .describe(
+            "Bundle identifier of the app to terminate (e.g., com.apple.mobilesafari)",
+          ),
+      }),
+      annotations: {
+        title: "Terminate App",
+        readOnlyHint: false,
+        openWorldHint: true,
+      },
     },
-    { title: "Terminate App", readOnlyHint: false, openWorldHint: true },
     async ({ udid, bundle_id }) => {
       try {
         const actualUdid = await getBootedDeviceId(udid);
@@ -1450,21 +1461,32 @@ if (!isToolFiltered("terminate_app")) {
 }
 
 if (!isToolFiltered("open_url")) {
-  server.tool(
+  server.registerTool(
     "open_url",
-    "Opens a URL in the iOS Simulator, useful for testing deep links and universal links",
     {
-      udid: z
-        .string()
-        .regex(UDID_REGEX)
-        .optional()
-        .describe("Udid of target, can also be set with the IDB_UDID env var"),
-      url: z
-        .string()
-        .max(2048)
-        .describe("The URL or deep link to open (e.g., https://example.com or myapp://screen/detail)"),
+      description:
+        "Opens a URL in the iOS Simulator, useful for testing deep links and universal links",
+      inputSchema: z.object({
+        udid: z
+          .string()
+          .regex(UDID_REGEX)
+          .optional()
+          .describe(
+            "Udid of target, can also be set with the IDB_UDID env var",
+          ),
+        url: z
+          .string()
+          .max(2048)
+          .describe(
+            "The URL or deep link to open (e.g., https://example.com or myapp://screen/detail)",
+          ),
+      }),
+      annotations: {
+        title: "Open URL",
+        readOnlyHint: false,
+        openWorldHint: true,
+      },
     },
-    { title: "Open URL", readOnlyHint: false, openWorldHint: true },
     async ({ udid, url }) => {
       try {
         const actualUdid = await getBootedDeviceId(udid);
@@ -1501,17 +1523,26 @@ if (!isToolFiltered("open_url")) {
 }
 
 if (!isToolFiltered("list_apps")) {
-  server.tool(
+  server.registerTool(
     "list_apps",
-    "Lists all installed apps on the iOS Simulator with their bundle identifiers and display names",
     {
-      udid: z
-        .string()
-        .regex(UDID_REGEX)
-        .optional()
-        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      description:
+        "Lists all installed apps on the iOS Simulator with their bundle identifiers and display names",
+      inputSchema: z.object({
+        udid: z
+          .string()
+          .regex(UDID_REGEX)
+          .optional()
+          .describe(
+            "Udid of target, can also be set with the IDB_UDID env var",
+          ),
+      }),
+      annotations: {
+        title: "List Installed Apps",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
     },
-    { title: "List Installed Apps", readOnlyHint: true, openWorldHint: true },
     async ({ udid }) => {
       try {
         const actualUdid = await getBootedDeviceId(udid);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,8 @@ const TMP_ROOT_DIR = fs.mkdtempSync(
  */
 type RunOptions = {
   env?: Record<string, string>;
+  /** Data piped to the child's stdin (e.g. feeding one command's output into another without a shell) */
+  input?: string;
 };
 
 async function run(
@@ -82,49 +84,21 @@ async function run(
   const mergedEnv = options.env
     ? { ...process.env, ...options.env }
     : process.env;
-  const { stdout, stderr } = await execFileAsync(cmd, args, {
+  const promise = execFileAsync(cmd, args, {
     shell: false,
     env: mergedEnv,
   });
+  if (options.input !== undefined && promise.child.stdin) {
+    // Tolerate EPIPE if the child exits before draining stdin; the promise
+    // still rejects on non-zero exit, so failures are not silenced.
+    promise.child.stdin.on("error", () => {});
+    promise.child.stdin.end(options.input);
+  }
+  const { stdout, stderr } = await promise;
   return {
     stdout: stdout.trim(),
     stderr: stderr.trim(),
   };
-}
-
-/**
- * Runs a command with arguments, pipes `stdin` to it, and returns the stdout and stderr.
- * Used when we need to feed the output of one command into another without going through a shell.
- */
-async function runWithStdin(
-  cmd: string,
-  args: string[],
-  stdin: string
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { shell: false });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(
-          new Error(
-            `${cmd} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`
-          )
-        );
-      } else {
-        resolve({ stdout: stdout.trim(), stderr: stderr.trim() });
-      }
-    });
-    child.stdin.end(stdin);
-  });
 }
 
 /**
@@ -1556,10 +1530,10 @@ if (!isToolFiltered("list_apps")) {
         // `simctl listapps` emits NeXTSTEP-style plist text that varies in
         // whitespace across Xcode versions. Delegate parsing to `plutil` which
         // converts it to JSON regardless of formatting quirks.
-        const { stdout: jsonText } = await runWithStdin(
+        const { stdout: jsonText } = await run(
           "plutil",
           ["-convert", "json", "-o", "-", "--", "-"],
-          plistText
+          { input: plistText },
         );
 
         const rawApps = JSON.parse(jsonText) as Record<

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,41 @@ async function run(
 }
 
 /**
+ * Runs a command with arguments, pipes `stdin` to it, and returns the stdout and stderr.
+ * Used when we need to feed the output of one command into another without going through a shell.
+ */
+async function runWithStdin(
+  cmd: string,
+  args: string[],
+  stdin: string
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { shell: false });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${cmd} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`
+          )
+        );
+      } else {
+        resolve({ stdout: stdout.trim(), stderr: stderr.trim() });
+      }
+    });
+    child.stdin.end(stdin);
+  });
+}
+
+/**
  * Gets the IDB command path from environment variable or defaults to "idb"
  * @returns The path to the IDB executable
  * @throws Error if custom path is specified but doesn't exist
@@ -1387,6 +1422,7 @@ if (!isToolFiltered("terminate_app")) {
           "simctl",
           "terminate",
           actualUdid,
+          "--",
           bundle_id,
         ]);
 
@@ -1440,6 +1476,7 @@ if (!isToolFiltered("open_url")) {
           "simctl",
           "openurl",
           actualUdid,
+          "--",
           url,
         ]);
 
@@ -1485,33 +1522,34 @@ if (!isToolFiltered("list_apps")) {
       try {
         const actualUdid = await getBootedDeviceId(udid);
 
-        const { stdout } = await run("xcrun", [
+        const { stdout: plistText } = await run("xcrun", [
           "simctl",
           "listapps",
           actualUdid,
         ]);
 
-        // Parse the plist output to extract bundle ID and display name
-        const apps: { bundleId: string; name: string }[] = [];
-        const bundleIdMatches = stdout.matchAll(/"([^"]+)" = \{/g);
+        // `simctl listapps` emits NeXTSTEP-style plist text that varies in
+        // whitespace across Xcode versions. Delegate parsing to `plutil` which
+        // converts it to JSON regardless of formatting quirks.
+        const { stdout: jsonText } = await runWithStdin(
+          "plutil",
+          ["-convert", "json", "-o", "-", "--", "-"],
+          plistText
+        );
 
-        for (const match of bundleIdMatches) {
-          const bundleId = match[1];
-          // Find the display name for this bundle
-          const blockStart = stdout.indexOf(match[0]);
-          const blockEnd = stdout.indexOf("\n    };", blockStart);
-          const block = stdout.slice(blockStart, blockEnd);
+        const rawApps = JSON.parse(jsonText) as Record<
+          string,
+          { CFBundleDisplayName?: string; CFBundleName?: string }
+        >;
 
-          const nameMatch =
-            block.match(/CFBundleDisplayName = "([^"]+)"/) ||
-            block.match(/CFBundleName = "([^"]+)"/);
-
-          const name = nameMatch ? nameMatch[1] : bundleId;
-          apps.push({ bundleId, name });
-        }
+        const apps = Object.entries(rawApps)
+          .map(([bundleId, info]) => ({
+            bundleId,
+            name: info.CFBundleDisplayName ?? info.CFBundleName ?? bundleId,
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name));
 
         const appList = apps
-          .sort((a, b) => a.name.localeCompare(b.name))
           .map((a) => `${a.name} — ${a.bundleId}`)
           .join("\n");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1363,6 +1363,184 @@ if (!isToolFiltered("launch_app")) {
   );
 }
 
+if (!isToolFiltered("terminate_app")) {
+  server.tool(
+    "terminate_app",
+    "Terminates a running app on the iOS Simulator by bundle identifier",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      bundle_id: z
+        .string()
+        .max(256)
+        .describe("Bundle identifier of the app to terminate (e.g., com.apple.mobilesafari)"),
+    },
+    { title: "Terminate App", readOnlyHint: false, openWorldHint: true },
+    async ({ udid, bundle_id }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        await run("xcrun", [
+          "simctl",
+          "terminate",
+          actualUdid,
+          bundle_id,
+        ]);
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `App ${bundle_id} terminated successfully`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error terminating app: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
+if (!isToolFiltered("open_url")) {
+  server.tool(
+    "open_url",
+    "Opens a URL in the iOS Simulator, useful for testing deep links and universal links",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+      url: z
+        .string()
+        .max(2048)
+        .describe("The URL or deep link to open (e.g., https://example.com or myapp://screen/detail)"),
+    },
+    { title: "Open URL", readOnlyHint: false, openWorldHint: true },
+    async ({ udid, url }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        await run("xcrun", [
+          "simctl",
+          "openurl",
+          actualUdid,
+          url,
+        ]);
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `Opened URL: ${url}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error opening URL: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
+if (!isToolFiltered("list_apps")) {
+  server.tool(
+    "list_apps",
+    "Lists all installed apps on the iOS Simulator with their bundle identifiers and display names",
+    {
+      udid: z
+        .string()
+        .regex(UDID_REGEX)
+        .optional()
+        .describe("Udid of target, can also be set with the IDB_UDID env var"),
+    },
+    { title: "List Installed Apps", readOnlyHint: true, openWorldHint: true },
+    async ({ udid }) => {
+      try {
+        const actualUdid = await getBootedDeviceId(udid);
+
+        const { stdout } = await run("xcrun", [
+          "simctl",
+          "listapps",
+          actualUdid,
+        ]);
+
+        // Parse the plist output to extract bundle ID and display name
+        const apps: { bundleId: string; name: string }[] = [];
+        const bundleIdMatches = stdout.matchAll(/"([^"]+)" = \{/g);
+
+        for (const match of bundleIdMatches) {
+          const bundleId = match[1];
+          // Find the display name for this bundle
+          const blockStart = stdout.indexOf(match[0]);
+          const blockEnd = stdout.indexOf("\n    };", blockStart);
+          const block = stdout.slice(blockStart, blockEnd);
+
+          const nameMatch =
+            block.match(/CFBundleDisplayName = "([^"]+)"/) ||
+            block.match(/CFBundleName = "([^"]+)"/);
+
+          const name = nameMatch ? nameMatch[1] : bundleId;
+          apps.push({ bundleId, name });
+        }
+
+        const appList = apps
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((a) => `${a.name} — ${a.bundleId}`)
+          .join("\n");
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: appList || "No apps found",
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: errorWithTroubleshooting(
+                `Error listing apps: ${toError(error).message}`
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
 async function runServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1418,13 +1418,10 @@ if (!isToolFiltered("terminate_app")) {
       try {
         const actualUdid = await getBootedDeviceId(udid);
 
-        await run("xcrun", [
-          "simctl",
-          "terminate",
-          actualUdid,
-          "--",
-          bundle_id,
-        ]);
+        // `simctl terminate` rejects a `--` separator (usage error). Flag
+        // parsing stops at the positional device argument, so passing the
+        // bundle id directly cannot be interpreted as an option.
+        await run("xcrun", ["simctl", "terminate", actualUdid, bundle_id]);
 
         return {
           isError: false,
@@ -1472,13 +1469,10 @@ if (!isToolFiltered("open_url")) {
       try {
         const actualUdid = await getBootedDeviceId(udid);
 
-        await run("xcrun", [
-          "simctl",
-          "openurl",
-          actualUdid,
-          "--",
-          url,
-        ]);
+        // `simctl openurl` treats `--` itself as the URL operand ("failed to
+        // open --"). Flag parsing stops at the positional device argument, so
+        // passing the url directly cannot be interpreted as an option.
+        await run("xcrun", ["simctl", "openurl", actualUdid, url]);
 
         return {
           isError: false,


### PR DESCRIPTION
## Summary

Rebased continuation of #61 by @saen-ai (their commits are preserved with authorship; the fork branch couldn't be updated directly). Adds three tools covering common QA workflows:

- **`terminate_app`** — kills a running app by bundle identifier (cold-start testing, state resets, crash-recovery flows)
- **`open_url`** — opens any URL or deep link in the simulator (custom schemes, universal links, OAuth redirects)
- **`list_apps`** — lists installed apps as sorted `name — bundleId` lines, parsing `simctl listapps` plist output via `plutil -convert json` over stdin (resilient to whitespace/format quirks across Xcode versions)

On top of the original two commits, this branch adds two fixups:

1. **fix: remove `--` separator from `simctl terminate`/`openurl`** — neither subcommand accepts it (`terminate` exits 117 with usage text; `openurl` treats `--` itself as the URL), so every call to both tools failed as originally pushed. simctl stops flag parsing at the positional device argument, so passing the values directly cannot be interpreted as options — verified with a `--help` injection probe. Code comments guard against a future "add `--` everywhere" sweep re-breaking this.
2. **refactor: convert the three tools to the SDK v2 `registerTool` API** — the branch predated #80.

The QA.md conflict was resolved by keeping the new version-agnostic Settings scenario and appending an App lifecycle scenario section in the same style.

## Test plan

Verified per TESTING.md's per-PR harness: sandboxed `claude -p --strict-mcp-config` session where the only MCP server is this branch's build, against a booted iPhone 17 Pro. All checks pass:

- [x] `list_apps` — 29/29 apps, exact match with `simctl listapps | plutil` ground truth, sorted, correct display names; same with explicit `udid`
- [x] `terminate_app` on a running app — process confirmed gone via `ps`; relaunch works
- [x] `terminate_app` on a not-running app — graceful error surfacing simctl's real "found nothing to terminate"
- [x] `open_url` with `https://example.com` — Safari renders Example Domain
- [x] `open_url` with `maps://?q=Portland` — Maps foregrounds
- [x] Zod rejects malformed `udid` at the schema
- [x] Injection probe: `open_url` with `--help` errors as a literal URL; no simctl help text leaks
- [x] Post-rebase regression: `get_booted_sim_id` and `ui_describe_all` intact on SDK v2

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)